### PR TITLE
Migrate to cats-effect 3.x and fs2 3.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -137,13 +137,14 @@ lazy val core = project
     commonSettings ++ testSettings ++ pgpSettings ++ publishingSettings ++ Seq(
       name := "fs2-mqtt",
       libraryDependencies ++= Seq(
-        ("org.specs2" %% "specs2-core" % "4.13.3" % "test").cross(CrossVersion.for3Use2_13),
-        ("com.codecommit" %% "cats-effect-testing-specs2" % "0.5.4" % "test").cross(CrossVersion.for3Use2_13),
-        "org.typelevel" %% "cats-effect-laws" % "2.5.1" % "test",
-        "org.scodec" %% "scodec-stream" % "2.0.2",
-        "co.fs2" %% "fs2-io" % "2.5.6",
-        "org.typelevel" %% "cats-effect" % "2.5.1",
-        ("com.github.cb372" %% "cats-retry" % "2.1.1").cross(CrossVersion.for3Use2_13)
+        ("org.specs2" %% "specs2-core" % "4.14.1" % "test").cross(CrossVersion.for3Use2_13),
+        "org.typelevel" %% "cats-effect-testing-specs2" % "1.4.0" % "test",
+        "org.typelevel" %% "cats-effect-laws" % "3.3.7" % "test",
+        "org.typelevel" %% "cats-effect-testkit"% "3.3.7" % "test",
+        "org.scodec" %% "scodec-stream" % "3.0.2",
+        "co.fs2" %% "fs2-io" % "3.2.5",
+        "org.typelevel" %% "cats-effect" % "3.3.8",
+        "com.github.cb372" %% "cats-retry" % "3.1.0"
       ) ++ {
         CrossVersion.partialVersion(scalaVersion.value) match {
           case Some((3, _)) => Seq()
@@ -162,8 +163,7 @@ lazy val examples = project
   .settings(
     commonSettings ++ Seq(
       libraryDependencies ++= Seq(
-        "io.monix" %% "monix" % "3.4.0",
-        "dev.zio" %% "zio-interop-cats" % "2.5.1.0"
+        "dev.zio" %% "zio-interop-cats" % "3.2.9.1"
       ),
       publish / skip := true
     )

--- a/core/src/main/scala/net/sigusr/mqtt/api/TransportConfig.scala
+++ b/core/src/main/scala/net/sigusr/mqtt/api/TransportConfig.scala
@@ -17,8 +17,9 @@
 package net.sigusr.mqtt.api
 
 import cats.Applicative
-import cats.effect.{Blocker, ContextShift, Sync}
-import fs2.io.tls.{TLSContext, TLSParameters}
+import cats.effect.Async
+import com.comcast.ip4s.{Host, Port}
+import fs2.io.net.tls.{TLSContext, TLSParameters}
 import net.sigusr.mqtt.api.PredefinedRetryPolicy.{ConstantDelay, ExponentialBackoff, FibonacciBackoff, FullJitter}
 import net.sigusr.mqtt.api.RetryConfig.Predefined
 import retry.{RetryPolicies, RetryPolicy}
@@ -70,25 +71,25 @@ object TLSContextKind {
   case object Insecure extends TLSContextKind
 }
 
-sealed case class TLSConfig[F[_]: Sync: ContextShift](
+sealed case class TLSConfig[F[_]: Async](
     private val tlsContextKind: TLSContextKind,
     tlsParameters: TLSParameters
 ) {
-  def contextOf(blocker: Blocker): F[TLSContext] =
+  def contextOf: F[TLSContext[F]] =
     tlsContextKind match {
-      case TLSContextKind.System   => TLSContext.system[F](blocker)
-      case TLSContextKind.Insecure => TLSContext.insecure[F](blocker)
+      case TLSContextKind.System   => TLSContext.Builder.forAsync[F].system
+      case TLSContextKind.Insecure => TLSContext.Builder.forAsync[F].insecure
     }
 }
 
 object TLSConfig {
-  def apply[F[_]: Sync: ContextShift](tlsContextKind: TLSContextKind, tlsParameters: TLSParameters = TLSParameters()) =
+  def apply[F[_]: Async](tlsContextKind: TLSContextKind, tlsParameters: TLSParameters = TLSParameters()) =
     new TLSConfig[F](tlsContextKind, tlsParameters)
 }
 
 sealed case class TransportConfig[F[_]](
-    host: String,
-    port: Int,
+    host: Host,
+    port: Port,
     tlsConfig: Option[TLSConfig[F]] = None,
     readTimeout: Option[FiniteDuration] = None,
     writeTimeout: Option[FiniteDuration] = None,

--- a/core/src/main/scala/net/sigusr/mqtt/impl/protocol/AtomicMap.scala
+++ b/core/src/main/scala/net/sigusr/mqtt/impl/protocol/AtomicMap.scala
@@ -17,7 +17,7 @@
 package net.sigusr.mqtt.impl.protocol
 
 import cats.effect.Concurrent
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import cats.implicits._
 
 import scala.collection.immutable.TreeMap

--- a/core/src/main/scala/net/sigusr/mqtt/impl/protocol/Transport.scala
+++ b/core/src/main/scala/net/sigusr/mqtt/impl/protocol/Transport.scala
@@ -100,7 +100,7 @@ object Transport {
       def pump(socket: Socket[F]): F[Unit] =
         for {
           _ <- connector.stateSignal.set(Connected)
-          _ <- outgoing(socket).race(incoming(socket)).race(closeSignalWatcher)
+          _ <- outgoing(socket).race(incoming(socket)).race(closeSignalWatcher(socket))
         } yield ()
 
 

--- a/core/src/main/scala/net/sigusr/mqtt/impl/protocol/Transport.scala
+++ b/core/src/main/scala/net/sigusr/mqtt/impl/protocol/Transport.scala
@@ -81,8 +81,8 @@ object Transport {
         .compile
         .drain
 
-    def closeSignalWatcher: F[Unit] =
-      connector.closeSignal.discrete.compile.drain // TODO evalMap(if (_) socket.close else Concurrent[F].pure(()))
+    def closeSignalWatcher(socket: Socket[F]): F[Unit] =
+      connector.closeSignal.discrete.evalMap(if (_) socket.endOfOutput else Concurrent[F].pure(())).compile.drain
 
     def loop(): F[Unit] = {
 

--- a/core/src/main/scala/net/sigusr/mqtt/impl/protocol/package.scala
+++ b/core/src/main/scala/net/sigusr/mqtt/impl/protocol/package.scala
@@ -16,13 +16,9 @@
 
 package net.sigusr.mqtt.impl
 
-import cats.effect.Sync
-
 package object protocol {
 
   val DEFAULT_KEEP_ALIVE: Int = 30
   val QUEUE_SIZE = 128
-
-  def putStrLn[F[_]: Sync](s: String): F[Unit] = Sync[F].delay(println(s))
 
 }

--- a/core/src/test/scala/net/sigusr/mqtt/SpecUtils.scala
+++ b/core/src/test/scala/net/sigusr/mqtt/SpecUtils.scala
@@ -16,7 +16,6 @@
 
 package net.sigusr.mqtt
 
-import cats.effect.{ContextShift, IO, Timer}
 import org.specs2.matcher.{Expectable, MatchResult, Matcher}
 import scodec.{Attempt, Err}
 
@@ -52,12 +51,5 @@ object SpecUtils {
     val bytes = new Array[Byte](size)
     Random.nextBytes(bytes)
     bytes.toVector
-  }
-
-  class CatsContext {
-    import cats.effect.laws.util.TestContext
-    implicit lazy val ec: TestContext = TestContext.apply()
-    implicit lazy val cs: ContextShift[IO] = IO.contextShift(ec)
-    implicit lazy val ioTimer: Timer[IO] = ec.timer[IO]
   }
 }

--- a/core/src/test/scala/net/sigusr/mqtt/impl/protocol/IdGeneratorSpec.scala
+++ b/core/src/test/scala/net/sigusr/mqtt/impl/protocol/IdGeneratorSpec.scala
@@ -1,15 +1,15 @@
 package net.sigusr.mqtt.impl.protocol
 
 import cats.effect.IO
-import cats.effect.testing.specs2.CatsIO
+import cats.effect.testing.specs2.CatsEffect
 import org.specs2.mutable._
 
-class IdGeneratorSpec extends Specification with CatsIO {
+class IdGeneratorSpec extends Specification with CatsEffect {
 
   "An id generator" should {
 
     "Provide the next id" in {
-      IdGenerator[IO](41).map { g =>
+      IdGenerator[IO](41).flatMap { g =>
         for {
           _ <- g.next
           n <- g.next
@@ -18,7 +18,7 @@ class IdGeneratorSpec extends Specification with CatsIO {
     }
 
     "Provide ids modulus 65535" in {
-      IdGenerator[IO](65534).map { g =>
+      IdGenerator[IO](65534).flatMap { g =>
         for {
           _ <- g.next
           n <- g.next

--- a/core/src/test/scala/net/sigusr/mqtt/impl/protocol/TickerSpec.scala
+++ b/core/src/test/scala/net/sigusr/mqtt/impl/protocol/TickerSpec.scala
@@ -1,9 +1,9 @@
 package net.sigusr.mqtt.impl.protocol
 
 import cats.effect.IO
-import cats.effect.concurrent.Ref
+import cats.effect.Ref
 import cats.effect.testing.specs2.CatsEffect
-import cats.implicits.catsSyntaxFlatMapOps
+import cats.effect.testkit.TestControl
 import org.specs2.mutable._
 
 import scala.concurrent.duration.DurationInt
@@ -12,59 +12,57 @@ class TickerSpec extends Specification with CatsEffect {
   "A ticker" should {
 
     "Trigger a program when an given time is elapsed" in {
-      val context = new net.sigusr.mqtt.SpecUtils.CatsContext
-      import context._
-      Ref[IO].of(false) >>= { ref =>
-        Ticker[IO](30, ref.set(true)).unsafeToFuture()
-        ec.tick(31.seconds)
-        ref.get.map(_ must beTrue)
-      }
+      for {
+        ref <- Ref[IO].of(false)
+        control <- TestControl.execute(Ticker[IO](30, ref.set(true)))
+        _ <- control.advanceAndTick(31.seconds)
+        result <- ref.get.map(_ must beTrue)
+      } yield result
     }
 
     "Not trigger a program when an given time is not yet elapsed" in {
-      val context = new net.sigusr.mqtt.SpecUtils.CatsContext
-      import context._
-      Ref[IO].of(false) >>= { ref =>
-        Ticker[IO](30, ref.set(true)).unsafeToFuture()
-        ec.tick(29.seconds)
-        ref.get.map(_ must beFalse)
-      }
+      for {
+        ref <- Ref[IO].of(false)
+        control <- TestControl.execute(Ticker[IO](30, ref.set(true)))
+        _ <- control.advanceAndTick(29.seconds)
+        result <- ref.get.map(_ must beFalse)
+      } yield result
     }
 
     "Not trigger a program when an given time is elapsed but it has been reset" in {
-      val context = new net.sigusr.mqtt.SpecUtils.CatsContext
-      import context._
-      Ref[IO].of(false).flatMap { ref =>
-        Ticker[IO](30, ref.set(true))
-          .flatMap { t =>
-            ioTimer.sleep(20.seconds) *> t.reset
-          }
-          .unsafeToFuture()
-        ec.tick(30.seconds)
-        ref.get.map(_ must beFalse)
-      }
+      for {
+        ref <- Ref[IO].of(false)
+        control <- TestControl.execute(
+          Ticker[IO](30, ref.set(true))
+            .flatMap { t =>
+              IO.sleep(20.seconds) *> t.reset
+            }
+        )
+        _ <- control.advanceAndTick(30.seconds)
+        result <- ref.get.map(_ must beFalse)
+      } yield result
     }
 
     "Be cancellable" in {
-      val context = new net.sigusr.mqtt.SpecUtils.CatsContext
-      import context._
-      Ref[IO].of(false).flatMap { ref =>
-        val ticker = Ticker[IO](30, ref.set(true))
-        ticker
-          .flatMap { t =>
-            ioTimer.sleep(30.seconds) *> t.cancel
-          }
-          .unsafeToFuture()
-        ec.tick(30.seconds)
-        ref.get.map(_ must beFalse)
-        ticker
-          .flatMap { t =>
-            ioTimer.sleep(31.seconds) *> t.cancel
-          }
-          .unsafeToFuture()
-        ec.tick(30.seconds)
-        ref.get.map(_ must beTrue)
-      }
+      for {
+        ref <- Ref[IO].of(false)
+        control <- TestControl.execute{
+          Ticker[IO](30, ref.set(true))
+            .flatMap { t =>
+              IO.sleep(30.seconds) *> t.cancel
+            }
+        }
+        _ <- control.advanceAndTick(30.seconds)
+        result <- ref.get.map(_ must beFalse)
+        control2 <- TestControl.execute{
+          Ticker[IO](30, ref.set(true))
+            .flatMap { t =>
+              IO.sleep(31.seconds) *> t.cancel
+            }
+        }
+        _ <- control2.advanceAndTick(30.seconds)
+        result2 <- ref.get.map(_ must beTrue)
+      } yield result.and(result2)
     }
   }
 }

--- a/examples/src/main/scala/net/sigusr/mqtt/examples/LocalPublisher.scala
+++ b/examples/src/main/scala/net/sigusr/mqtt/examples/LocalPublisher.scala
@@ -16,29 +16,32 @@
 
 package net.sigusr.mqtt.examples
 
-import cats.effect.ExitCode
+import cats.effect.std.Console
 import cats.implicits._
+import com.comcast.ip4s.IpLiteralSyntax
 import fs2.Stream
-import monix.eval.{Task, TaskApp}
 import net.sigusr.mqtt.api.QualityOfService.{AtLeastOnce, AtMostOnce, ExactlyOnce}
 import net.sigusr.mqtt.api._
+import zio.interop.catz._
+import zio.interop.catz.implicits._
+import zio.{ExitCode, _}
 
 import scala.concurrent.duration._
 import scala.util.Random
 
-object LocalPublisher extends TaskApp {
+object LocalPublisher extends App {
 
-  private val random: Stream[Task, Int] = Stream.eval(Task.delay(Math.abs(Random.nextInt()))).repeat
+  private val random: Stream[Task, Int] = Stream.eval(Task(Math.abs(Random.nextInt()))).repeat
   private val topics =
     Stream(("AtMostOnce", AtMostOnce), ("AtLeastOnce", AtLeastOnce), ("ExactlyOnce", ExactlyOnce)).repeat
 
-  override def run(args: List[String]): Task[ExitCode] =
+  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
     if (args.nonEmpty) {
       val messages = args.toVector
       val transportConfig =
         TransportConfig[Task](
-          "localhost",
-          1883,
+          host"localhost",
+          port"1883",
           // TLS support looks like
           // 8883,
           // tlsConfig = Some(TLSConfig(TLSContextKind.System)),
@@ -46,6 +49,7 @@ object LocalPublisher extends TaskApp {
         )
       val sessionConfig =
         SessionConfig(s"$localPublisher", user = Some(localPublisher), password = Some("yala"), keepAlive = 5)
+      implicit val console: Console[Task] = Console.make[Task]
       Session[Task](transportConfig, sessionConfig)
         .use { session =>
           val sessionStatus = session.state.discrete
@@ -60,20 +64,19 @@ object LocalPublisher extends TaskApp {
             qos = m._2._2
             _ <- Stream.eval(
               putStrLn[Task](
-                s"Publishing on topic ${Console.CYAN}$topic${Console.RESET} with QoS " +
-                  s"${Console.CYAN}${qos.show}${Console.RESET} message ${Console.BOLD}$message${Console.RESET}"
+                s"Publishing on topic ${scala.Console.CYAN}$topic${scala.Console.RESET} with QoS " +
+                  s"${scala.Console.CYAN}${qos.show}${scala.Console.RESET} message ${scala.Console.BOLD}$message${scala.Console.RESET}"
               )
             )
             _ <- Stream.eval(session.publish(topic, payload(message), qos))
           } yield ()).compile.drain
-          for {
-            _ <- Task.race(publisher, sessionStatus)
-          } yield ExitCode.Success
+
+          publisher.race(sessionStatus)
         }
-        .handleErrorWith(_ => Task.pure(ExitCode.Error))
+        .fold(_ => ExitCode.failure, _ => ExitCode.success)
     } else
-      putStrLn[Task](s"${Console.RED}At least one or more « messages » should be provided.${Console.RESET}")
-        .as(ExitCode.Error)
+      putStrLn[Task](s"${scala.Console.RED}At least one or more « messages » should be provided.${scala.Console.RESET}")
+        .fold(_ => ExitCode.failure, _ => ExitCode.success)
 
   private def ticks(): Stream[Task, Unit] =
     random.flatMap { r =>


### PR DESCRIPTION
This PR migrates `fs2-mqtt` to the latest `cats-effect` and `fs2` versions. This of course breaks compatibility with CE2 and fs2 2.x.

Problems:
- I converted the `LocalPublisher` example from Monix to ZIO as Monix doesn't support CE3.
- [ ] I rewrote the `TickerSpec` to use the `TestControl` from CE3, but the test doesn't work. The `Ticker` itself seems to work just fine, so it must have something to do with my inability to use the `TestControl` properly.
- [ ] In `Transport` I had some issues caused by the removal of timeouts and `close` from fs2's `Socket`. 
