### PR TITLE
Migrate to fs2-scodec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,8 +141,8 @@ lazy val core = project
         "org.typelevel" %% "cats-effect-testing-specs2" % "1.4.0" % "test",
         "org.typelevel" %% "cats-effect-laws" % "3.4.7" % "test",
         "org.typelevel" %% "cats-effect-testkit"% "3.4.7" % "test",
-        "org.scodec" %% "scodec-stream" % "3.0.2",
-        "co.fs2" %% "fs2-io" % "3.7.0",
+        "co.fs2" %% "fs2-io" % "3.10.2",
+        "co.fs2" %% "fs2-scodec" % "3.10.2",
         "org.typelevel" %% "cats-effect" % "3.4.11",
         "com.github.cb372" %% "cats-retry" % "3.1.0"
       ) ++ {

--- a/core/src/main/scala/net/sigusr/mqtt/impl/protocol/Transport.scala
+++ b/core/src/main/scala/net/sigusr/mqtt/impl/protocol/Transport.scala
@@ -33,7 +33,7 @@ import net.sigusr.mqtt.impl.frames.Frame
 import retry.RetryDetails.{GivingUp, WillDelayAndRetry}
 import retry._
 import scodec.Codec
-import scodec.stream.{StreamDecoder, StreamEncoder}
+import fs2.interop.scodec.{StreamDecoder, StreamEncoder}
 
 import scala.concurrent.duration._
 


### PR DESCRIPTION
https://github.com/scodec/scodec-stream has been merged into fs2 (https://fs2.io/#/scodec).

Only package change. The API seems to be the same.